### PR TITLE
feat: allow using ubuntu distros for podman installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The action is cross-platform, working for both ubuntu-latest and windows-latest 
 
 On Windows, it uses the official Podman MSI installer, automatically fetching the latest version. You can specify a specific Podman version if your CI needs to be pinned. After installation, the action automatically runs podman machine init --now to ensure the Podman machine is running and ready for use in subsequent steps.
 
-On Linux, the action installs Podman v5.x and its key dependencies (like CRIU) from the openSUSE Kubic repository, ensuring you get a modern version.
+On Linux, the action installs Podman v5.x and its key dependencies (like CRIU) from the openSUSE Kubic repository or from another Ubuntu distros, ensuring you get more modern version into GH runners.
 
 ### Inputs
 
@@ -17,6 +17,8 @@ This action accepts three inputs to customize its behavior:
 **podman-version-input**: This input is used only on Windows runners. You can set it to 'latest' (which is the default) to automatically install the most recent Podman release, or provide a specific version string (e.g., '5.6.2') to install that exact version.
 
 **ubuntu-version**: This input is used only on Linux runners. It specifies the Ubuntu version codename (like '23.10' or '22.04') needed to construct the correct URL for the Kubic repository. The default value is '23.10'.
+
+**ubuntu-repository**: This input is used only on Linux. It offers new option how to install a podman. With the parameter, the particular repositories can be used to install podman and its dependencies. The input is a choice type and it offers to choose from `questing` (default), `resolute`, `noble` or `kubic` repository. If `kubic` is used, then installation will also consider *ubuntu-version* input parameter and use Kubic repositories. Note: If `resolute` is picked up, it will lead to a system upgrade due to incompatible `libc6` library dependency between distros.
 
 **github-token**: (Optional) A GitHub token used to make authenticated API requests when fetching the latest Podman version on Windows. Providing this token helps avoid GitHub API rate limiting, especially in workflows that run frequently. If not provided, the action will make unauthenticated requests which are subject to stricter rate limits. Example: `github-token: ${{ secrets.GITHUB_TOKEN }}`.
 
@@ -48,11 +50,21 @@ This action accepts three inputs to customize its behavior:
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-### Custom Ubuntu Version for Linux
-
+### Install Podman 5.2.5 on Ubuntu from Kubic repositories 23.10
 ```yaml
-- name: Install Podman on Ubuntu 22.04
+# Use kubic repository 23.10 (contains podman 5.2.5)
+- name: Install Podman on Ubuntu 24.04 from Kubic
   uses: redhat-actions/podman-install@main
   with:
-    ubuntu-version: '22.04'
+    ubuntu-version: '23.10'
+    ubuntu-repository: 'kubic'
+```
+
+### Install Podman 5.4.2 on Ubuntu from Questing distribution repository
+```yaml
+# Use kubic repository 23.10 (contains podman 5.2.5)
+- name: Install Podman on Ubuntu from Questing repository
+  uses: redhat-actions/podman-install@main
+  with:
+    ubuntu-repository: 'questing'
 ```

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,15 @@ inputs:
     description: "The Ubuntu version codename for the Kubic repository."
     required: false
     default: "23.10"
+  ubuntu-repository:
+    description: "The Ubuntu distro source to use for podman, ie: questing, resolute, noble. Or use openSUSE's kubic repo"
+    required: false
+    options:
+    - questing
+    - kubic
+    - resolute
+    - noble
+    default: questing
   podman-version-input:
     description: "Podman version for Windows. Use 'latest' or a specific version (e.g. '5.6.2')."
     required: false
@@ -39,8 +48,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Update podman to 5.x on Linux
-      if: runner.os == 'Linux'
+    - name: Update podman to 5.x on Linux from Kubic repository
+      if: ${{ runner.os == 'Linux' && inputs.ubuntu-repository == 'kubic' }}
       shell: bash
       run: |
         ubuntu_version='${{ inputs.ubuntu-version }}'
@@ -70,6 +79,37 @@ runs:
 
         echo "INFO: Podman installation complete."
         podman version
+
+    - name: Update podman to 5.x on Linux from ${{ github.event.inputs.ubuntu-repository }} repository
+      if: ${{ runner.os == 'Linux' && inputs.ubuntu-repository != 'kubic' }}
+      shell: bash
+      run: |
+        set -eux
+        ubuntu_repo="${{ inputs.ubuntu-repository }}"
+        echo "INFO: Using ${ubuntu_repo} Ubuntu repository for podman installation."
+        # Require the runner is ubuntu-24.04
+        IDV=$(. /usr/lib/os-release && echo ${ID}-${VERSION_ID})
+        echo "Actual Ubuntu version: ${IDV}"
+        echo "deb http://azure.archive.ubuntu.com/ubuntu ${ubuntu_repo} universe main" | sudo tee /etc/apt/sources.list.d/${ubuntu_repo}.list
+        /bin/time -f '%E %C' sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/${ubuntu_repo}.list" \
+          -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+        # Disable auto upgrade for this repository
+        sudo tee /etc/apt/preferences.d/${ubuntu_repo} <<EOF
+        Package: *
+        Pin: release n=${ubuntu_repo}
+        Pin-Priority: 50
+        
+        Package: podman criu crun skopeo buildah
+        Pin: release n=${ubuntu_repo}
+        Pin-Priority: 500
+        EOF
+        /bin/time -f '%E %C' sudo apt install -y --allow-downgrades criu/${ubuntu_repo} crun/${ubuntu_repo} podman/${ubuntu_repo} skopeo/${ubuntu_repo}
+        AFTER_IDV=$(. /usr/lib/os-release && echo ${ID}-${VERSION_ID})
+        if [[ "$AFTER_IDV" != "$IDV" ]]; then
+          echo "### WARNING Ubuntu was upgraded from $IDV to $AFTER_IDV"
+        fi
+        echo "Actual ubuntu version: ${AFTER_IDV}"
+        echo "Actual podman installed: $(podman -v)"
 
     - name: Fetch Podman Download URL for Windows
       if: runner.os == 'Windows'


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description
Add new input parameter to allow to choose an ubuntu distro for podman installation. Defaults to `questing` repositories with podman 5.4.2. We intend to have more recent and stable repository since previous Kubic repositories are not well maintained nor supported anymore. 
<!--
A short and simple description of what this PR aims to accomplish.
-->

### Related Issue(s)
#8 
<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

<!--
A list of changes within this PR
  - new input param: ubuntu-distro, defaults to `questing` for podman installation on linux
  - Updated README
-->
