### PR TITLE
feat(windows): add nightly MSI fetch to fetch-latest-podman-version-windows sub-action

### DIFF
--- a/.github/actions/fetch-latest-podman-version-windows/action.yml
+++ b/.github/actions/fetch-latest-podman-version-windows/action.yml
@@ -82,6 +82,7 @@ runs:
           echo "GitHub Token: not provided"
         fi
 
+        # Input validation
         if [ -z "$INPUT_VERSION" ]; then
           echo "Error: Version input cannot be empty"
           exit 1
@@ -163,6 +164,7 @@ runs:
         if [ "$INPUT_VERSION" = "latest" ]; then
           echo "Fetching latest Podman release..."
 
+          # Fetch latest release with error handling
           if [ -n "$GITHUB_TOKEN" ]; then
             echo "Using GITHUB_TOKEN for authenticated API request."
             API_RESPONSE=$(curl -sL -H "Authorization: Bearer $GITHUB_TOKEN" "https://api.github.com/repos/${PODMAN_REPO}/releases/latest")
@@ -171,12 +173,14 @@ runs:
             API_RESPONSE=$(curl -sL "https://api.github.com/repos/${PODMAN_REPO}/releases/latest")
           fi
 
+          # Check for API errors (rate limiting, etc.)
           if echo "$API_RESPONSE" | jq -e '.message' >/dev/null 2>&1; then
             ERROR_MESSAGE=$(echo "$API_RESPONSE" | jq -r '.message')
             echo "Error: GitHub API returned an error: $ERROR_MESSAGE"
             exit 1
           fi
 
+          # Parse version with validation
           LATEST_VERSION=$(echo "$API_RESPONSE" | jq -r '.tag_name')
           if [ "$LATEST_VERSION" = "null" ] || [ -z "$LATEST_VERSION" ]; then
             echo "Error: Could not parse version from GitHub API response"
@@ -221,6 +225,7 @@ runs:
           VERSION_NUMBER=${LATEST_VERSION#v}
         fi
 
+        # Construct Windows download URL
         case "$FILE_TYPE" in
           setup.exe)
             DOWNLOAD_URL="https://github.com/${PODMAN_REPO}/releases/download/${LATEST_VERSION}/podman-${VERSION_NUMBER}-setup.exe"
@@ -242,6 +247,8 @@ runs:
         esac
 
         echo "Download URL: $DOWNLOAD_URL"
+
+        # Validate that the download URL actually exists
         echo "Validating download URL..."
         HTTP_CODE=$(curl -sL -o /dev/null -w "%{http_code}" -I "$DOWNLOAD_URL")
         if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "302" ]; then

--- a/.github/actions/fetch-latest-podman-version-windows/action.yml
+++ b/.github/actions/fetch-latest-podman-version-windows/action.yml
@@ -15,11 +15,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: 'Fetch Latest Podman Version for Windows'
-description: 'Fetches the latest Podman release version and constructs Windows download URLs'
+description: 'Fetches Podman release or nightly build artifacts and prepares Windows installer URLs or local paths'
 
 inputs:
   version_input:
-    description: 'Version input - use "latest" to auto-fetch, or provide specific version'
+    description: 'Use "latest" for stable release, "nightly" or "main" for main branch CI artifacts, or a specific version/URL'
     required: true
     default: 'latest'
   architecture:
@@ -31,129 +31,208 @@ inputs:
     required: false
     default: 'msi'
   github_token:
-    description: 'GitHub token to make authenticated API requests'
+    description: 'GitHub token to make authenticated API requests (required for nightly artifacts)'
     required: false
+  nightly_branch:
+    description: 'Branch label used in nightly artifact names (main or latest release branch)'
+    required: false
+    default: 'main'
 
 outputs:
   version:
-    description: 'The Podman version (e.g., v5.6.1)'
+    description: 'The Podman version (e.g., v5.6.1 or main-451b71f for nightly)'
     value: ${{ steps.fetch.outputs.version }}
   download_url:
-    description: 'The constructed download URL'
+    description: 'Public download URL for release artifacts'
     value: ${{ steps.fetch.outputs.download_url }}
+  local_installer_path:
+    description: 'Local path to a downloaded nightly MSI on the runner'
+    value: ${{ steps.fetch.outputs.local_installer_path }}
   is_latest:
-    description: 'Whether the latest version was fetched (true/false)'
+    description: 'Whether the latest release version was fetched (true/false)'
     value: ${{ steps.fetch.outputs.is_latest }}
+  is_nightly:
+    description: 'Whether a nightly CI artifact was fetched (true/false)'
+    value: ${{ steps.fetch.outputs.is_nightly }}
 
 runs:
   using: 'composite'
   steps:
-    - name: Fetch Podman version and construct URL
+    - name: Fetch Podman version and installer
       id: fetch
       shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version_input }}
+        ARCHITECTURE: ${{ inputs.architecture }}
+        FILE_TYPE: ${{ inputs.file_type }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        NIGHTLY_BRANCH: ${{ inputs.nightly_branch }}
+        PODMAN_REPO: podman-container-tools/podman
+        NIGHTLY_WORKFLOW: release-pipeline-validation.yml
       run: |
-        INPUT_VERSION="${{ inputs.version_input }}"
-        ARCHITECTURE="${{ inputs.architecture }}"
-        FILE_TYPE="${{ inputs.file_type }}"
-        GITHUB_TOKEN="${{ inputs.github_token }}"
-        
+        set -euo pipefail
+
         echo "Input version: $INPUT_VERSION"
         echo "Architecture: $ARCHITECTURE"
         echo "File type: $FILE_TYPE"
+        echo "Nightly branch: $NIGHTLY_BRANCH"
         if [ -n "$GITHUB_TOKEN" ]; then
           echo "GitHub Token: ***"
         else
           echo "GitHub Token: not provided"
         fi
-        
-        # Input validation
+
         if [ -z "$INPUT_VERSION" ]; then
           echo "Error: Version input cannot be empty"
           exit 1
         fi
-        
-        if [ "$INPUT_VERSION" = "latest" ]; then
-          echo "Fetching latest Podman release..."
-          
-          # Check if jq is available
-          if ! command -v jq &> /dev/null; then
-            echo "Error: jq is required but not installed"
+
+        if ! command -v jq >/dev/null 2>&1; then
+          echo "Error: jq is required but not installed"
+          exit 1
+        fi
+
+        gh_api() {
+          if [ -z "$GITHUB_TOKEN" ]; then
+            echo "Error: github_token is required for this operation"
+            exit 1
+          fi
+          gh api "$@" --header "Authorization: Bearer ${GITHUB_TOKEN}"
+        }
+
+        if [ "$INPUT_VERSION" = "nightly" ] || [ "$INPUT_VERSION" = "main" ]; then
+          echo "Fetching latest successful Podman nightly artifacts from GitHub Actions..."
+
+          RUN_ID="$(gh_api "repos/${PODMAN_REPO}/actions/workflows/${NIGHTLY_WORKFLOW}/runs?status=success&per_page=20" \
+            --jq '.workflow_runs[0].id')"
+
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "Error: Could not find a successful ${NIGHTLY_WORKFLOW} workflow run"
             exit 1
           fi
 
-          # Fetch latest release with error handling
+          echo "Using workflow run: $RUN_ID"
+
+          ARTIFACT_PREFIX="win-msi-${ARCHITECTURE}-${NIGHTLY_BRANCH}-"
+          ARTIFACT_NAME="$(gh_api "repos/${PODMAN_REPO}/actions/runs/${RUN_ID}/artifacts" \
+            --jq ".artifacts[] | select(.name | startswith(\"${ARTIFACT_PREFIX}\")) | .name" | head -n1)"
+
+          if [ -z "$ARTIFACT_NAME" ]; then
+            echo "Error: Could not find artifact matching prefix ${ARTIFACT_PREFIX} in run ${RUN_ID}"
+            gh_api "repos/${PODMAN_REPO}/actions/runs/${RUN_ID}/artifacts" --jq '.artifacts[].name'
+            exit 1
+          fi
+
+          ARTIFACT_ID="$(gh_api "repos/${PODMAN_REPO}/actions/runs/${RUN_ID}/artifacts" \
+            --jq ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id")"
+
+          VERSION_SUFFIX="${ARTIFACT_NAME#${ARTIFACT_PREFIX}}"
+          VERSION="main-${VERSION_SUFFIX}"
+
+          WORKDIR="${RUNNER_TEMP}/podman-nightly-${VERSION_SUFFIX}"
+          mkdir -p "$WORKDIR"
+          ARTIFACT_ZIP="${WORKDIR}/artifact.zip"
+
+          echo "Downloading artifact ${ARTIFACT_NAME} (id=${ARTIFACT_ID})..."
+          gh_api "repos/${PODMAN_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" > "$ARTIFACT_ZIP"
+          unzip -qo "$ARTIFACT_ZIP" -d "$WORKDIR/extracted"
+
+          MSI_PATH="$(find "$WORKDIR/extracted" -type f -name '*.msi' | head -n1)"
+          if [ -z "$MSI_PATH" ]; then
+            echo "Error: No MSI file found inside artifact ${ARTIFACT_NAME}"
+            find "$WORKDIR/extracted" -type f
+            exit 1
+          fi
+
+          FINAL_MSI="${WORKDIR}/$(basename "$MSI_PATH")"
+          if [ "$MSI_PATH" != "$FINAL_MSI" ]; then
+            mv "$MSI_PATH" "$FINAL_MSI"
+          fi
+
+          echo "Nightly Podman version: $VERSION"
+          echo "Local installer: $FINAL_MSI"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "local_installer_path=$FINAL_MSI" >> "$GITHUB_OUTPUT"
+          echo "is_latest=false" >> "$GITHUB_OUTPUT"
+          echo "is_nightly=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "is_nightly=false" >> "$GITHUB_OUTPUT"
+
+        if [ "$INPUT_VERSION" = "latest" ]; then
+          echo "Fetching latest Podman release..."
+
           if [ -n "$GITHUB_TOKEN" ]; then
             echo "Using GITHUB_TOKEN for authenticated API request."
-            API_RESPONSE=$(curl -sL -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/podman-container-tools/podman/releases/latest)
+            API_RESPONSE=$(curl -sL -H "Authorization: Bearer $GITHUB_TOKEN" "https://api.github.com/repos/${PODMAN_REPO}/releases/latest")
           else
             echo "Warning: GITHUB_TOKEN is not set. API requests may be subject to stricter rate limits."
-            API_RESPONSE=$(curl -sL https://api.github.com/repos/podman-container-tools/podman/releases/latest)
+            API_RESPONSE=$(curl -sL "https://api.github.com/repos/${PODMAN_REPO}/releases/latest")
           fi
-          
-          # Check for API errors (rate limiting, etc.)
+
           if echo "$API_RESPONSE" | jq -e '.message' >/dev/null 2>&1; then
             ERROR_MESSAGE=$(echo "$API_RESPONSE" | jq -r '.message')
             echo "Error: GitHub API returned an error: $ERROR_MESSAGE"
             exit 1
           fi
-          
-          # Parse version with validation
+
           LATEST_VERSION=$(echo "$API_RESPONSE" | jq -r '.tag_name')
           if [ "$LATEST_VERSION" = "null" ] || [ -z "$LATEST_VERSION" ]; then
             echo "Error: Could not parse version from GitHub API response"
             exit 1
           fi
-          
+
           echo "Latest Podman version: $LATEST_VERSION"
-          echo "version=$LATEST_VERSION" >> $GITHUB_OUTPUT
-          echo "is_latest=true" >> $GITHUB_OUTPUT
+          echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+          echo "is_latest=true" >> "$GITHUB_OUTPUT"
           VERSION_NUMBER=${LATEST_VERSION#v}
         elif [[ "$INPUT_VERSION" =~ ^https?:// ]]; then
-          # Full URL provided, use as-is
+          if [[ "$INPUT_VERSION" == *$'\n'* || "$INPUT_VERSION" == *$'\r'* ]]; then
+            echo "Error: URL input cannot contain newline characters"
+            exit 1
+          fi
+
           echo "Full URL provided: $INPUT_VERSION"
-          echo "download_url=$INPUT_VERSION" >> $GITHUB_OUTPUT
-          echo "is_latest=false" >> $GITHUB_OUTPUT
-          # Try to extract version from URL for version output
+          echo "download_url=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "is_latest=false" >> "$GITHUB_OUTPUT"
           if [[ "$INPUT_VERSION" =~ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-            echo "version=v${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+            echo "version=v${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
           else
-            echo "version=custom" >> $GITHUB_OUTPUT
+            echo "version=custom" >> "$GITHUB_OUTPUT"
           fi
           exit 0
         else
-          # Specific version provided
           echo "Specific version provided: $INPUT_VERSION"
-          
-          # Validate version format (should be semver-like: v5.6.1, 5.6.1, v5.6.1-rc1, etc.)
+
           if [[ ! "$INPUT_VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-](rc|alpha|beta)[0-9]*)?$ ]]; then
             echo "Error: Invalid version format: $INPUT_VERSION"
-            echo "Expected formats: v5.6.1, 5.6.1, v5.6.1-rc1, 5.6.1-rc1, etc."
+            echo "Expected formats: latest, nightly, v5.6.1, 5.6.1, or a full URL"
             exit 1
           fi
-          
+
           if [[ "$INPUT_VERSION" =~ ^v ]]; then
             LATEST_VERSION="$INPUT_VERSION"
           else
             LATEST_VERSION="v$INPUT_VERSION"
           fi
-          echo "version=$LATEST_VERSION" >> $GITHUB_OUTPUT
-          echo "is_latest=false" >> $GITHUB_OUTPUT
+          echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+          echo "is_latest=false" >> "$GITHUB_OUTPUT"
           VERSION_NUMBER=${LATEST_VERSION#v}
         fi
-        
-        # Construct Windows download URL
+
         case "$FILE_TYPE" in
-          "setup.exe")
-            DOWNLOAD_URL="https://github.com/podman-container-tools/podman/releases/download/${LATEST_VERSION}/podman-${VERSION_NUMBER}-setup.exe"
+          setup.exe)
+            DOWNLOAD_URL="https://github.com/${PODMAN_REPO}/releases/download/${LATEST_VERSION}/podman-${VERSION_NUMBER}-setup.exe"
             ;;
-          "installer.exe")
-            DOWNLOAD_URL="https://github.com/podman-container-tools/podman/releases/download/${LATEST_VERSION}/podman-installer-windows-${ARCHITECTURE}.exe"
+          installer.exe)
+            DOWNLOAD_URL="https://github.com/${PODMAN_REPO}/releases/download/${LATEST_VERSION}/podman-installer-windows-${ARCHITECTURE}.exe"
             ;;
-          "remote.zip")
-            DOWNLOAD_URL="https://github.com/podman-container-tools/podman/releases/download/${LATEST_VERSION}/podman-remote-release-windows_${ARCHITECTURE}.zip"
+          remote.zip)
+            DOWNLOAD_URL="https://github.com/${PODMAN_REPO}/releases/download/${LATEST_VERSION}/podman-remote-release-windows_${ARCHITECTURE}.zip"
             ;;
-          "msi")
-            DOWNLOAD_URL="https://github.com/podman-container-tools/podman/releases/download/${LATEST_VERSION}/podman-installer-windows-${ARCHITECTURE}.msi"
+          msi)
+            DOWNLOAD_URL="https://github.com/${PODMAN_REPO}/releases/download/${LATEST_VERSION}/podman-installer-windows-${ARCHITECTURE}.msi"
             ;;
           *)
             echo "Error: Unsupported Windows file type: $FILE_TYPE"
@@ -161,10 +240,8 @@ runs:
             exit 1
             ;;
         esac
-        
+
         echo "Download URL: $DOWNLOAD_URL"
-        
-        # Validate that the download URL actually exists
         echo "Validating download URL..."
         HTTP_CODE=$(curl -sL -o /dev/null -w "%{http_code}" -I "$DOWNLOAD_URL")
         if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "302" ]; then
@@ -173,6 +250,6 @@ runs:
           echo "This may indicate the version doesn't exist or the file type isn't available for this version"
           exit 1
         fi
-        
+
         echo "Download URL validated successfully"
-        echo "download_url=$DOWNLOAD_URL" >> $GITHUB_OUTPUT
+        echo "download_url=$DOWNLOAD_URL" >> "$GITHUB_OUTPUT"

--- a/.github/actions/fetch-latest-podman-version-windows/action.yml
+++ b/.github/actions/fetch-latest-podman-version-windows/action.yml
@@ -14,12 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: 'Fetch Latest Podman Version for Windows'
-description: 'Fetches Podman release or nightly build artifacts and prepares Windows installer URLs or local paths'
+name: 'Fetch Podman Version for Windows'
+description: 'Resolves Podman release download URLs or downloads nightly Windows MSI artifacts from podman-container-tools/podman CI'
 
 inputs:
   version_input:
-    description: 'Use "latest" for stable release, "nightly" or "main" for main branch CI artifacts, or a specific version/URL'
+    description: 'Use "latest" for the stable release, "nightly" or "main" for main-branch CI artifacts, a semver like "v5.6.1" or "5.6.1", or a full download URL'
     required: true
     default: 'latest'
   architecture:
@@ -27,14 +27,14 @@ inputs:
     required: false
     default: 'amd64'
   file_type:
-    description: 'File type for Windows (setup.exe, installer.exe, remote.zip, msi)'
+    description: 'Release asset type: setup.exe, installer.exe, remote.zip, or msi (ignored for nightly; nightly always fetches MSI artifacts)'
     required: false
     default: 'msi'
   github_token:
-    description: 'GitHub token to make authenticated API requests (required for nightly artifacts)'
+    description: 'GitHub token for authenticated API requests. Required for nightly artifacts; optional but recommended for release lookups to avoid rate limits'
     required: false
   nightly_branch:
-    description: 'Branch label used in nightly artifact names (main or latest release branch)'
+    description: 'Branch label in nightly artifact names (e.g. "main" selects win-msi-amd64-main-<sha>)'
     required: false
     default: 'main'
 
@@ -43,10 +43,10 @@ outputs:
     description: 'The Podman version (e.g., v5.6.1 or main-451b71f for nightly)'
     value: ${{ steps.fetch.outputs.version }}
   download_url:
-    description: 'Public download URL for release artifacts'
+    description: 'Public GitHub Release download URL. Set for latest, specific version, and URL inputs; empty for nightly'
     value: ${{ steps.fetch.outputs.download_url }}
   local_installer_path:
-    description: 'Local path to a downloaded nightly MSI on the runner'
+    description: 'Absolute path to a downloaded nightly MSI on the runner. Set only when version_input is nightly or main'
     value: ${{ steps.fetch.outputs.local_installer_path }}
   is_latest:
     description: 'Whether the latest release version was fetched (true/false)'

--- a/README.md
+++ b/README.md
@@ -68,3 +68,99 @@ This action accepts three inputs to customize its behavior:
   with:
     ubuntu-repository: 'questing'
 ```
+
+## Sub-action: Fetch Podman Version for Windows
+
+The composite sub-action at `.github/actions/fetch-latest-podman-version-windows` resolves a Podman Windows installer without installing it. Use it when your workflow needs the download URL or a locally fetched nightly MSI—for example, to install Podman on a remote Windows host.
+
+The main `podman-install` action uses this sub-action internally on Windows runners. It currently passes through `latest` or a specific release version only. To consume nightly CI builds, call the sub-action directly (see examples below).
+
+### Version resolution
+
+| `version_input` | Source | Primary output |
+| --- | --- | --- |
+| `latest` | [podman-container-tools/podman](https://github.com/podman-container-tools/podman) GitHub Release | `download_url` |
+| `v5.6.1` / `5.6.1` | Same, pinned tag | `download_url` |
+| `https://…` | URL used as-is (validated for CR/LF) | `download_url` |
+| `nightly` / `main` | Latest successful [release-pipeline-validation.yml](https://github.com/podman-container-tools/podman/actions/workflows/release-pipeline-validation.yml) run; artifact `win-msi-<arch>-<nightly_branch>-<sha>` | `local_installer_path` |
+
+`file_type` applies to release downloads only. Nightly resolution always downloads the MSI artifact from CI.
+
+Release artifacts are fetched from `podman-container-tools/podman`. Nightly MSIs are GitHub Actions artifacts and require an authenticated download via the GitHub CLI (`gh`).
+
+### Requirements for nightly
+
+- `github_token` must be provided (typically `${{ secrets.GITHUB_TOKEN }}`)
+- The workflow job needs `permissions.actions: read`
+- The runner must have `gh` and `jq` available (pre-installed on `ubuntu-latest` and `windows-latest`)
+
+### Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `version_input` | yes | `latest` | Version selector (see table above) |
+| `architecture` | no | `amd64` | Windows architecture: `amd64` or `arm64` |
+| `file_type` | no | `msi` | Release asset type: `msi`, `setup.exe`, `installer.exe`, or `remote.zip` |
+| `github_token` | no* | — | GitHub token; *required for nightly |
+| `nightly_branch` | no | `main` | Branch label in nightly artifact names |
+
+### Outputs
+
+| Output | Description |
+| --- | --- |
+| `version` | Resolved version (e.g. `v5.6.1` or `main-696772b`) |
+| `download_url` | Public release download URL (unset for nightly) |
+| `local_installer_path` | Path to nightly MSI on the runner (unset for release) |
+| `is_latest` | `true` when `version_input` was `latest` |
+| `is_nightly` | `true` when a CI nightly artifact was downloaded |
+
+### Fetch latest stable release
+
+```yaml
+permissions:
+  contents: read
+
+steps:
+  - id: fetch-podman
+    uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@main
+    with:
+      version_input: latest
+      file_type: msi
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  - run: curl -LO '${{ steps.fetch-podman.outputs.download_url }}'
+```
+
+### Fetch a specific release
+
+```yaml
+  - id: fetch-podman
+    uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@main
+    with:
+      version_input: v5.6.1
+      architecture: amd64
+      file_type: msi
+```
+
+### Fetch nightly CI build
+
+```yaml
+permissions:
+  contents: read
+  actions: read
+
+steps:
+  - id: fetch-podman
+    uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@main
+    with:
+      version_input: nightly
+      architecture: amd64
+      file_type: msi
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  - run: |
+      echo "version=${{ steps.fetch-podman.outputs.version }}"
+      ls -la "${{ steps.fetch-podman.outputs.local_installer_path }}"
+```
+
+Pin the sub-action to a commit SHA instead of `@main` in production workflows.


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description

Extends the `fetch-latest-podman-version-windows` composite sub-action to support Podman nightly Windows MSIs from the `podman-container-tools/podman` CI pipeline.

When `version_input` is `nightly` or `main`, the action finds the latest successful `release-pipeline-validation.yml` workflow run, downloads the matching `win-msi-<arch>-<branch>-<sha>` artifact via authenticated `gh api`, and exposes the extracted MSI path through a new `local_installer_path` output.

Release resolution (`latest`, specific version, or full URL) is unchanged and still returns a public `download_url`. README documentation for the sub-action is added, including inputs, outputs, requirements, and usage examples.

### Related Issue(s)

- podman-desktop/e2e#586
- https://github.com/podman-container-tools/podman/issues/29059 (artifact naming / distinguishing main vs release branch)

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

- Add `nightly` / `main` support to `fetch-latest-podman-version-windows` using `release-pipeline-validation.yml` artifacts from `podman-container-tools/podman`
- Add `local_installer_path` and `is_nightly` outputs; keep `is_latest` for backward compatibility
- Add `nightly_branch` input (default `main`) to select artifact name prefix
- Require `github_token` for nightly downloads; document `permissions.actions: read` requirement
- Add URL newline validation for custom `version_input` URLs
- Update sub-action metadata (name, descriptions, `file_type` docs)
- Document the sub-action in `README.md` with resolution table, requirements, and release/nightly examples