### PR TITLE
ci: change downloading nightly bits to get url

### DIFF
--- a/.github/actions/fetch-latest-podman-version-windows/action.yml
+++ b/.github/actions/fetch-latest-podman-version-windows/action.yml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: 'Fetch Podman Version for Windows'
-description: 'Resolves Podman release download URLs or downloads nightly Windows MSI artifacts from podman-container-tools/podman CI'
+description: 'Resolves Podman Windows installer download URLs for releases or nightly CI artifacts from podman-container-tools/podman'
 
 inputs:
   version_input:
@@ -27,32 +27,25 @@ inputs:
     required: false
     default: 'amd64'
   file_type:
-    description: 'Release asset type: setup.exe, installer.exe, remote.zip, or msi (ignored for nightly; nightly always fetches MSI artifacts)'
+    description: 'Release asset type: setup.exe, installer.exe, remote.zip, or msi (ignored for nightly; nightly always resolves MSI artifacts)'
     required: false
     default: 'msi'
   github_token:
     description: 'GitHub token for authenticated API requests. Required for nightly artifacts; optional but recommended for release lookups to avoid rate limits'
     required: false
-  nightly_branch:
-    description: 'Branch label in nightly artifact names (e.g. "main" selects win-msi-amd64-main-<sha>)'
-    required: false
-    default: 'main'
 
 outputs:
   version:
     description: 'The Podman version (e.g., v5.6.1 or main-451b71f for nightly)'
     value: ${{ steps.fetch.outputs.version }}
   download_url:
-    description: 'Public GitHub Release download URL. Set for latest, specific version, and URL inputs; empty for nightly'
+    description: 'Installer download URL. Public release asset URL for latest/version/URL inputs; authenticated Actions artifact archive URL for nightly'
     value: ${{ steps.fetch.outputs.download_url }}
-  local_installer_path:
-    description: 'Absolute path to a downloaded nightly MSI on the runner. Set only when version_input is nightly or main'
-    value: ${{ steps.fetch.outputs.local_installer_path }}
   is_latest:
     description: 'Whether the latest release version was fetched (true/false)'
     value: ${{ steps.fetch.outputs.is_latest }}
   is_nightly:
-    description: 'Whether a nightly CI artifact was fetched (true/false)'
+    description: 'Whether a nightly CI artifact URL was resolved (true/false)'
     value: ${{ steps.fetch.outputs.is_nightly }}
 
 runs:
@@ -66,7 +59,6 @@ runs:
         ARCHITECTURE: ${{ inputs.architecture }}
         FILE_TYPE: ${{ inputs.file_type }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
-        NIGHTLY_BRANCH: ${{ inputs.nightly_branch }}
         PODMAN_REPO: podman-container-tools/podman
         NIGHTLY_WORKFLOW: release-pipeline-validation.yml
       run: |
@@ -75,7 +67,6 @@ runs:
         echo "Input version: $INPUT_VERSION"
         echo "Architecture: $ARCHITECTURE"
         echo "File type: $FILE_TYPE"
-        echo "Nightly branch: $NIGHTLY_BRANCH"
         if [ -n "$GITHUB_TOKEN" ]; then
           echo "GitHub Token: ***"
         else
@@ -102,7 +93,7 @@ runs:
         }
 
         if [ "$INPUT_VERSION" = "nightly" ] || [ "$INPUT_VERSION" = "main" ]; then
-          echo "Fetching latest successful Podman nightly artifacts from GitHub Actions..."
+          echo "Resolving latest successful Podman nightly artifact URL from GitHub Actions..."
 
           RUN_ID="$(gh_api "repos/${PODMAN_REPO}/actions/workflows/${NIGHTLY_WORKFLOW}/runs?status=success&per_page=20" \
             --jq '.workflow_runs[0].id')"
@@ -114,7 +105,7 @@ runs:
 
           echo "Using workflow run: $RUN_ID"
 
-          ARTIFACT_PREFIX="win-msi-${ARCHITECTURE}-${NIGHTLY_BRANCH}-"
+          ARTIFACT_PREFIX="win-msi-${ARCHITECTURE}-main-"
           ARTIFACT_NAME="$(gh_api "repos/${PODMAN_REPO}/actions/runs/${RUN_ID}/artifacts" \
             --jq ".artifacts[] | select(.name | startswith(\"${ARTIFACT_PREFIX}\")) | .name" | head -n1)"
 
@@ -127,33 +118,22 @@ runs:
           ARTIFACT_ID="$(gh_api "repos/${PODMAN_REPO}/actions/runs/${RUN_ID}/artifacts" \
             --jq ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id")"
 
-          VERSION_SUFFIX="${ARTIFACT_NAME#${ARTIFACT_PREFIX}}"
-          VERSION="main-${VERSION_SUFFIX}"
+          DOWNLOAD_URL="$(gh_api "repos/${PODMAN_REPO}/actions/artifacts/${ARTIFACT_ID}" \
+            --jq '.archive_download_url')"
 
-          WORKDIR="${RUNNER_TEMP}/podman-nightly-${VERSION_SUFFIX}"
-          mkdir -p "$WORKDIR"
-          ARTIFACT_ZIP="${WORKDIR}/artifact.zip"
-
-          echo "Downloading artifact ${ARTIFACT_NAME} (id=${ARTIFACT_ID})..."
-          gh_api "repos/${PODMAN_REPO}/actions/artifacts/${ARTIFACT_ID}/zip" > "$ARTIFACT_ZIP"
-          unzip -qo "$ARTIFACT_ZIP" -d "$WORKDIR/extracted"
-
-          MSI_PATH="$(find "$WORKDIR/extracted" -type f -name '*.msi' | head -n1)"
-          if [ -z "$MSI_PATH" ]; then
-            echo "Error: No MSI file found inside artifact ${ARTIFACT_NAME}"
-            find "$WORKDIR/extracted" -type f
+          if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
+            echo "Error: Could not resolve archive_download_url for artifact ${ARTIFACT_NAME} (id=${ARTIFACT_ID})"
             exit 1
           fi
 
-          FINAL_MSI="${WORKDIR}/$(basename "$MSI_PATH")"
-          if [ "$MSI_PATH" != "$FINAL_MSI" ]; then
-            mv "$MSI_PATH" "$FINAL_MSI"
-          fi
+          VERSION_SUFFIX="${ARTIFACT_NAME#${ARTIFACT_PREFIX}}"
+          VERSION="main-${VERSION_SUFFIX}"
 
           echo "Nightly Podman version: $VERSION"
-          echo "Local installer: $FINAL_MSI"
+          echo "Artifact: ${ARTIFACT_NAME} (id=${ARTIFACT_ID})"
+          echo "Download URL: $DOWNLOAD_URL"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "local_installer_path=$FINAL_MSI" >> "$GITHUB_OUTPUT"
+          echo "download_url=$DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
           echo "is_latest=false" >> "$GITHUB_OUTPUT"
           echo "is_nightly=true" >> "$GITHUB_OUTPUT"
           exit 0

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This action accepts three inputs to customize its behavior:
 
 ## Sub-action: Fetch Podman Version for Windows
 
-The composite sub-action at `.github/actions/fetch-latest-podman-version-windows` resolves a Podman Windows installer without installing it. Use it when your workflow needs the download URL or a locally fetched nightly MSI—for example, to install Podman on a remote Windows host.
+The composite sub-action at `.github/actions/fetch-latest-podman-version-windows` resolves a Podman Windows installer download URL without installing it. Use it when your workflow needs the URL—for example, to download and install Podman on a remote Windows host.
 
 The main `podman-install` action uses this sub-action internally on Windows runners. It currently passes through `latest` or a specific release version only. To consume nightly CI builds, call the sub-action directly (see examples below).
 
@@ -79,18 +79,18 @@ The main `podman-install` action uses this sub-action internally on Windows runn
 
 | `version_input` | Source | Primary output |
 | --- | --- | --- |
-| `latest` | [podman-container-tools/podman](https://github.com/podman-container-tools/podman) GitHub Release | `download_url` |
-| `v5.6.1` / `5.6.1` | Same, pinned tag | `download_url` |
+| `latest` | [podman-container-tools/podman](https://github.com/podman-container-tools/podman) GitHub Release | `download_url` (public MSI/asset URL) |
+| `v5.6.1` / `5.6.1` | Same, pinned tag | `download_url` (public MSI/asset URL) |
 | `https://…` | URL used as-is (validated for CR/LF) | `download_url` |
-| `nightly` / `main` | Latest successful [release-pipeline-validation.yml](https://github.com/podman-container-tools/podman/actions/workflows/release-pipeline-validation.yml) run; artifact `win-msi-<arch>-<nightly_branch>-<sha>` | `local_installer_path` |
+| `nightly` / `main` | Latest successful [release-pipeline-validation.yml](https://github.com/podman-container-tools/podman/actions/workflows/release-pipeline-validation.yml) run; artifact `win-msi-<arch>-main-<sha>` | `download_url` (Actions artifact archive URL) |
 
-`file_type` applies to release downloads only. Nightly resolution always downloads the MSI artifact from CI.
+`file_type` applies to release downloads only. Nightly resolution always targets the MSI CI artifact (`win-msi-<arch>-main-<sha>`).
 
-Release artifacts are fetched from `podman-container-tools/podman`. Nightly MSIs are GitHub Actions artifacts and require an authenticated download via the GitHub CLI (`gh`).
+Release assets are public download URLs. Nightly `download_url` is the GitHub Actions [`archive_download_url`](https://docs.github.com/en/rest/actions/artifacts#get-an-artifact) for the matching artifact (a zip archive containing the MSI). Downloading that URL requires an authenticated request with a token that has `actions: read` on `podman-container-tools/podman`.
 
 ### Requirements for nightly
 
-- `github_token` must be provided (typically `${{ secrets.GITHUB_TOKEN }}`)
+- `github_token` must be provided (typically `${{ secrets.GITHUB_TOKEN }}`, or a PAT with access to the Podman repo artifacts)
 - The workflow job needs `permissions.actions: read`
 - The runner must have `gh` and `jq` available (pre-installed on `ubuntu-latest` and `windows-latest`)
 
@@ -102,17 +102,15 @@ Release artifacts are fetched from `podman-container-tools/podman`. Nightly MSIs
 | `architecture` | no | `amd64` | Windows architecture: `amd64` or `arm64` |
 | `file_type` | no | `msi` | Release asset type: `msi`, `setup.exe`, `installer.exe`, or `remote.zip` |
 | `github_token` | no* | — | GitHub token; *required for nightly |
-| `nightly_branch` | no | `main` | Branch label in nightly artifact names |
 
 ### Outputs
 
 | Output | Description |
 | --- | --- |
 | `version` | Resolved version (e.g. `v5.6.1` or `main-696772b`) |
-| `download_url` | Public release download URL (unset for nightly) |
-| `local_installer_path` | Path to nightly MSI on the runner (unset for release) |
+| `download_url` | Installer download URL (public release asset, or authenticated Actions artifact archive for nightly) |
 | `is_latest` | `true` when `version_input` was `latest` |
-| `is_nightly` | `true` when a CI nightly artifact was downloaded |
+| `is_nightly` | `true` when a CI nightly artifact URL was resolved |
 
 ### Fetch latest stable release
 
@@ -155,12 +153,14 @@ steps:
     with:
       version_input: nightly
       architecture: amd64
-      file_type: msi
       github_token: ${{ secrets.GITHUB_TOKEN }}
 
   - run: |
       echo "version=${{ steps.fetch-podman.outputs.version }}"
-      ls -la "${{ steps.fetch-podman.outputs.local_installer_path }}"
+      curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+        -o podman-nightly.zip \
+        '${{ steps.fetch-podman.outputs.download_url }}'
+      unzip -qo podman-nightly.zip
 ```
 
 Pin the sub-action to a commit SHA instead of `@main` in production workflows.


### PR DESCRIPTION
### Description

Follow-up to [#24](https://github.com/redhat-actions/podman-install/pull/24): simplify nightly handling in `fetch-latest-podman-version-windows` so it resolves an artifact download URL (like release flows) instead of downloading the MSI on the runner, and drop the unused `nightly_branch` input.

### Related Issue(s)

* Switch pulling the Podman nightly artifacts from actual available CI system [podman-desktop/e2e#586](https://github.com/podman-desktop/e2e/issues/586)
* Follow-up to [redhat-actions/podman-install#24](https://github.com/redhat-actions/podman-install/pull/24)
* Closes https://github.com/redhat-actions/podman-install/issues/25

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [x] This change is a major (breaking) change

### Changes made

* Remove the `nightly_branch` input; nightly artifacts always use the `win-msi-<arch>-main-<sha>` name prefix
* Stop downloading/unzipping nightly artifacts on the runner; resolve `archive_download_url` via the GitHub Actions Artifacts API and expose it as `download_url`
* Remove the `local_installer_path` output
* Update sub-action docs/examples in `README.md` for the URL-based nightly flow (authenticated download + unzip)