### PR TITLE
fix: action bugs, CI modernization, and security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Podman
         uses: ./
@@ -63,7 +63,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Podman
         uses: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+# /**********************************************************************
+#  * Copyright (C) 2025 Red Hat, Inc.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#  *
+#  * SPDX-License-Identifier: Apache-2.0
+#  ***********************************************************************/
+
+# Validates that the podman-install action works on both Linux and Windows
+# runners. Runs on every PR and on pushes to main so regressions are caught
+# before a release tag is created.
+
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-linux:
+    name: Test on Linux (ubuntu-24.04)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Podman
+        uses: ./
+        with:
+          ubuntu-repository: questing
+
+      - name: Verify Podman is installed
+        run: |
+          set -euo pipefail
+          echo "Podman version:"
+          podman --version
+          echo "Podman info:"
+          podman info --format '{{.Host.OS}} {{.Host.Arch}} {{.Version.Version}}'
+
+  test-windows:
+    name: Test on Windows (windows-latest)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Podman
+        uses: ./
+        with:
+          podman-version-input: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify Podman is installed
+        shell: pwsh
+        run: |
+          podman --version
+          podman machine list

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,26 +23,25 @@ on:
     branches:
       - main
 
+# Prevent overlapping releases when multiple commits are pushed in quick
+# succession (e.g. merge queue). Only the latest push needs a release.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   create_release:
     runs-on: ubuntu-24.04
     permissions:
       contents: write # Grant permission to create releases/tags
     steps:
-      # This new step manually calculates the short SHA
-      - name: Get short SHA
-        id: get_sha
-        run: echo "sha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-
-      # This step now uses the output from the step above
       - name: Create Release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: commit-${{ steps.get_sha.outputs.sha }}
-          release_name: Release ${{ steps.get_sha.outputs.sha }}
-          body: |
-            Automatic release created from commit ${{ github.sha }} on the main branch.
-          draft: false
-          prerelease: true
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          short_sha=$(echo "${{ github.sha }}" | cut -c1-7)
+          gh release create "commit-${short_sha}" \
+            --repo "${{ github.repository }}" \
+            --title "Release ${short_sha}" \
+            --notes "Automatic release created from commit ${{ github.sha }} on the main branch." \
+            --prerelease

--- a/action.yml
+++ b/action.yml
@@ -171,24 +171,32 @@ runs:
       run: |
         $installScope = "${{ inputs.install-scope }}"
         
-        echo "Adding Podman to PATH for this session..."
+        echo "Adding Podman to PATH..."
         # New MSI installer locations (user-scope and machine-scope)
         $userScopePath = "$env:LOCALAPPDATA\Programs\Podman"
         $machineScopePath = "$env:ProgramFiles\Podman"
         # Legacy installer location (for backward compatibility)
         $legacyPath = "$env:ProgramFiles\RedHat\Podman"
-        
+
+        $podmanDir = $null
         # Check based on install scope first, then fall back to other locations
         if ($installScope -eq "machine" -and (Test-Path $machineScopePath)) {
-          $env:PATH += ";$machineScopePath"
+          $podmanDir = $machineScopePath
         } elseif ($installScope -eq "user" -and (Test-Path $userScopePath)) {
-          $env:PATH += ";$userScopePath"
+          $podmanDir = $userScopePath
         } elseif (Test-Path $userScopePath) {
-          $env:PATH += ";$userScopePath"
+          $podmanDir = $userScopePath
         } elseif (Test-Path $machineScopePath) {
-          $env:PATH += ";$machineScopePath"
+          $podmanDir = $machineScopePath
         } elseif (Test-Path $legacyPath) {
-          $env:PATH += ";$legacyPath"
+          $podmanDir = $legacyPath
+        }
+
+        if ($podmanDir) {
+          # Add to current step's PATH
+          $env:PATH += ";$podmanDir"
+          # Persist for subsequent steps in the consuming workflow
+          echo $podmanDir >> $env:GITHUB_PATH
         }
         
         $podmanPath = (Get-Command podman).Path

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,7 @@ runs:
       if: ${{ runner.os == 'Linux' && inputs.ubuntu-repository == 'kubic' }}
       shell: bash
       run: |
+        set -euo pipefail
         ubuntu_version='${{ inputs.ubuntu-version }}'
         echo "INFO: Using Ubuntu version '${ubuntu_version}' for Kubic repository."
 
@@ -87,7 +88,7 @@ runs:
         echo "INFO: Podman installation complete."
         podman version
 
-    - name: Update podman to 5.x on Linux from ${{ github.event.inputs.ubuntu-repository }} repository
+    - name: Update podman to 5.x on Linux from ${{ inputs.ubuntu-repository }} repository
       if: ${{ runner.os == 'Linux' && inputs.ubuntu-repository != 'kubic' }}
       shell: bash
       run: |
@@ -125,7 +126,7 @@ runs:
     - name: Fetch Podman Download URL for Windows
       if: runner.os == 'Windows'
       id: fetch-podman-url
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@50a7dd02e78b3747c2a19f110ac266e7306faec5
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
       with:
         version_input: ${{ inputs.podman-version-input || 'latest' }}
         github_token: ${{ inputs.github-token }}


### PR DESCRIPTION
## Summary

- **Fix Kubic step error handling**: added `set -euo pipefail` to the Kubic installation step, which previously had no shell error handling (unlike the non-Kubic step that already uses `set -eux`). Failures in apt-get, GPG key import, or curl were silently ignored.
- **Fix step name expression context**: changed `${{ github.event.inputs.ubuntu-repository }}` to `${{ inputs.ubuntu-repository }}` in the non-Kubic step name. `github.event.inputs` is only populated for `workflow_dispatch` triggers, not composite actions, so the step name was rendering blank.
- **Update stale sub-action SHA**: the sub-action was pinned to `50a7dd0` but 6 commits including bug fixes (org redirect, curl follow-redirects) and the nightly feature had landed since. Updated to `60b05ab` (current HEAD).
- **Replace archived `actions/create-release`**: replaced with `gh release create` which is built into all GitHub runners and actively maintained. Simplified from 2 steps to 1.
- **Add concurrency group to release workflow**: prevents overlapping release jobs when multiple commits are pushed in quick succession.
- **Add CI test workflow**: the repo previously had no automated testing. New `ci.yml` tests the action on Linux (ubuntu-24.04 with questing repo) and Windows (latest Podman via MSI installer) on every PR and push to main.
- **Add Dependabot configuration**: weekly monitoring for GitHub Actions version updates.
- **Set default workflow permissions to read-only** (API change, already applied): was `write`. The release workflow already declares `permissions: contents: write` explicitly, so it is unaffected.

## Test plan

- [ ] CI workflow runs successfully on this PR (Linux job)
- [ ] CI workflow runs successfully on this PR (Windows job)
- [ ] Verify release workflow syntax is valid (will be tested on merge to main)
- [ ] Confirm Dependabot starts opening PRs for action version updates within a week

🤖 Generated with [Claude Code](https://claude.com/claude-code)