### PR TITLE
feat: add start-service input and fix ARM architecture support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,27 @@ jobs:
           echo "Podman info:"
           podman info --format '{{.Host.OS}} {{.Host.Arch}} {{.Version.Version}}'
 
+  test-linux-arm:
+    name: Test on Linux ARM (ubuntu-24.04-arm)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Podman
+        uses: ./
+        with:
+          ubuntu-repository: questing
+
+      - name: Verify Podman is installed
+        run: |
+          set -euo pipefail
+          echo "Architecture: $(dpkg --print-architecture)"
+          echo "Podman version:"
+          podman --version
+          echo "Podman info:"
+          podman info --format '{{.Host.OS}} {{.Host.Arch}} {{.Version.Version}}'
+
   test-windows:
     name: Test on Windows (windows-latest)
     runs-on: windows-latest

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This action accepts three inputs to customize its behavior:
 
 **ubuntu-repository**: This input is used only on Linux. It offers new option how to install a podman. With the parameter, the particular repositories can be used to install podman and its dependencies. The input is a choice type and it offers to choose from `questing` (default), `resolute`, `noble` or `kubic` repository. If `kubic` is used, then installation will also consider *ubuntu-version* input parameter and use Kubic repositories. Note: If `resolute` is picked up, it will lead to a system upgrade due to incompatible `libc6` library dependency between distros.
 
+**start-service**: (Optional, Linux only) When set to `'true'`, starts the Podman socket service (`systemctl --user start podman.socket`) after installation. Useful for workflows that interact with Podman via the API socket rather than the CLI. Defaults to `'false'`.
+
 **github-token**: (Optional) A GitHub token used to make authenticated API requests when fetching the latest Podman version on Windows. Providing this token helps avoid GitHub API rate limiting, especially in workflows that run frequently. If not provided, the action will make unauthenticated requests which are subject to stricter rate limits. Example: `github-token: ${{ secrets.GITHUB_TOKEN }}`.
 
 ## Usage
@@ -58,6 +60,15 @@ This action accepts three inputs to customize its behavior:
   with:
     ubuntu-version: '23.10'
     ubuntu-repository: 'kubic'
+```
+
+### Install Podman and Start the Socket Service (Linux)
+
+```yaml
+- name: Install Podman with socket service
+  uses: redhat-actions/podman-install@main
+  with:
+    start-service: 'true'
 ```
 
 ### Install Podman 5.4.2 on Ubuntu from Questing distribution repository

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,13 @@ inputs:
     description: "Installation scope for Windows MSI installer. Use 'user' for user-scope (no admin required) or 'machine' for machine-scope (requires admin privileges)."
     required: false
     default: "user"
+  start-service:
+    description: "Start the Podman socket service after installation (Linux only). Runs 'systemctl --user start podman.socket'."
+    required: false
+    options:
+      - false
+      - true
+    default: 'false'
   github-token:
     description: "GitHub token to make authenticated API requests and avoid rate limiting."
     required: false
@@ -74,7 +81,8 @@ runs:
         sudo apt-get install --allow-unauthenticated -qq -y libprotobuf32t64 python3-protobuf libnet1
 
         echo "INFO: Installing CRIU manually..."
-        curl -sLO http://archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
+        ARCH=$(dpkg --print-architecture)
+        curl -sLO "http://archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_${ARCH}.deb" && sudo dpkg -i "criu_3.16.1-2_${ARCH}.deb"
 
         echo "INFO: Installing Podman..."
         sudo apt-get -qq -y install --allow-unauthenticated podman || {
@@ -122,6 +130,16 @@ runs:
         fi
         echo "Actual ubuntu version: ${AFTER_IDV}"
         echo "Actual podman installed: $(podman -v)"
+
+    - name: Start Podman socket service
+      if: ${{ runner.os == 'Linux' && inputs.start-service == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "INFO: Starting Podman socket service..."
+        systemctl --user start podman.socket
+        echo "INFO: Podman socket service started."
+        systemctl --user status podman.socket --no-pager
 
     - name: Fetch Podman Download URL for Windows
       if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary

- **Add `start-service` input** (closes #19): new optional boolean input that starts `podman.socket` via systemd after installation on Linux. Saves consumers from needing a separate step to enable the Podman API socket.
- **Fix hardcoded amd64 CRIU package** (closes #14): the Kubic installation path hardcoded `criu_3.16.1-2_amd64.deb`, which fails on ARM runners. Now uses `dpkg --print-architecture` to download the correct package. The non-Kubic path (questing/resolute/noble) already uses `apt install` which is architecture-agnostic.

## Test plan

- [ ] Linux CI job passes (validates the action still installs correctly)
- [ ] Verify `start-service: 'true'` starts the podman socket on a Linux runner
- [ ] Verify ARM architecture detection works (CRIU deb URL uses correct arch string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)