### PR TITLE
docs: update README for v1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,23 @@ This composite action installs Podman on GitHub-hosted runners for both Linux (U
 
 ## Features
 
-The action is cross-platform, working for both ubuntu-latest and windows-latest runners.
+The action is cross-platform, working for both Ubuntu and Windows runners (including ARM).
 
-On Windows, it uses the official Podman MSI installer, automatically fetching the latest version. You can specify a specific Podman version if your CI needs to be pinned. After installation, the action automatically runs podman machine init --now to ensure the Podman machine is running and ready for use in subsequent steps.
+On **Windows**, it uses the official Podman MSI installer, automatically fetching the latest version. You can specify a specific Podman version if your CI needs to be pinned. After installation, the action automatically runs `podman machine init --now` to ensure the Podman machine is running and ready for use in subsequent steps.
 
-On Linux, the action installs Podman v5.x and its key dependencies (like CRIU) from the openSUSE Kubic repository or from another Ubuntu distros, ensuring you get more modern version into GH runners.
+On **Linux**, the action installs Podman v5.x and its key dependencies (like CRIU) from Ubuntu distribution repositories or the openSUSE Kubic repository, ensuring you get a more modern version than what ships with the GitHub runner images.
 
-### Inputs
+## Inputs
 
-This action accepts three inputs to customize its behavior:
-
-**podman-version-input**: This input is used only on Windows runners. You can set it to 'latest' (which is the default) to automatically install the most recent Podman release, or provide a specific version string (e.g., '5.6.2') to install that exact version.
-
-**ubuntu-version**: This input is used only on Linux runners. It specifies the Ubuntu version codename (like '23.10' or '22.04') needed to construct the correct URL for the Kubic repository. The default value is '23.10'.
-
-**ubuntu-repository**: This input is used only on Linux. It offers new option how to install a podman. With the parameter, the particular repositories can be used to install podman and its dependencies. The input is a choice type and it offers to choose from `questing` (default), `resolute`, `noble` or `kubic` repository. If `kubic` is used, then installation will also consider *ubuntu-version* input parameter and use Kubic repositories. Note: If `resolute` is picked up, it will lead to a system upgrade due to incompatible `libc6` library dependency between distros.
-
-**start-service**: (Optional, Linux only) When set to `'true'`, starts the Podman socket service (`systemctl --user start podman.socket`) after installation. Useful for workflows that interact with Podman via the API socket rather than the CLI. Defaults to `'false'`.
-
-**github-token**: (Optional) A GitHub token used to make authenticated API requests when fetching the latest Podman version on Windows. Providing this token helps avoid GitHub API rate limiting, especially in workflows that run frequently. If not provided, the action will make unauthenticated requests which are subject to stricter rate limits. Example: `github-token: ${{ secrets.GITHUB_TOKEN }}`.
+| Input | Platform | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `ubuntu-repository` | Linux | no | `questing` | Ubuntu distro source: `questing`, `resolute`, `noble`, or `kubic` |
+| `ubuntu-version` | Linux | no | `23.10` | Ubuntu version codename for the Kubic repository (only used when `ubuntu-repository` is `kubic`) |
+| `allow-upgrade` | Linux | no | `false` | Allow upgrade of the Ubuntu system (may be needed for some repository/distro combinations) |
+| `start-service` | Linux | no | `false` | Start the Podman socket service (`systemctl --user start podman.socket`) after installation |
+| `podman-version-input` | Windows | no | `latest` | Podman version: `latest` or a specific version (e.g. `5.6.2`) |
+| `install-scope` | Windows | no | `user` | MSI installation scope: `user` (no admin required) or `machine` (requires admin) |
+| `github-token` | Windows | no | -- | GitHub token for authenticated API requests (avoids rate limiting) |
 
 ## Usage
 
@@ -30,14 +28,14 @@ This action accepts three inputs to customize its behavior:
 
 ```yaml
 - name: Install Podman
-  uses: redhat-actions/podman-install@main
+  uses: redhat-actions/podman-install@v1
 ```
 
 ### With GitHub Token (Recommended for Windows)
 
 ```yaml
 - name: Install Podman
-  uses: redhat-actions/podman-install@main
+  uses: redhat-actions/podman-install@v1
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -46,43 +44,43 @@ This action accepts three inputs to customize its behavior:
 
 ```yaml
 - name: Install Podman 5.6.2
-  uses: redhat-actions/podman-install@main
+  uses: redhat-actions/podman-install@v1
   with:
     podman-version-input: '5.6.2'
     github-token: ${{ secrets.GITHUB_TOKEN }}
-```
-
-### Install Podman 5.2.5 on Ubuntu from Kubic repositories 23.10
-```yaml
-# Use kubic repository 23.10 (contains podman 5.2.5)
-- name: Install Podman on Ubuntu 24.04 from Kubic
-  uses: redhat-actions/podman-install@main
-  with:
-    ubuntu-version: '23.10'
-    ubuntu-repository: 'kubic'
 ```
 
 ### Install Podman and Start the Socket Service (Linux)
 
 ```yaml
 - name: Install Podman with socket service
-  uses: redhat-actions/podman-install@main
+  uses: redhat-actions/podman-install@v1
   with:
     start-service: 'true'
 ```
 
-### Install Podman 5.4.2 on Ubuntu from Questing distribution repository
+### Install Podman on Ubuntu from Kubic Repository
+
 ```yaml
-# Use kubic repository 23.10 (contains podman 5.2.5)
+- name: Install Podman on Ubuntu 24.04 from Kubic
+  uses: redhat-actions/podman-install@v1
+  with:
+    ubuntu-version: '23.10'
+    ubuntu-repository: 'kubic'
+```
+
+### Install Podman from Questing Repository
+
+```yaml
 - name: Install Podman on Ubuntu from Questing repository
-  uses: redhat-actions/podman-install@main
+  uses: redhat-actions/podman-install@v1
   with:
     ubuntu-repository: 'questing'
 ```
 
 ## Sub-action: Fetch Podman Version for Windows
 
-The composite sub-action at `.github/actions/fetch-latest-podman-version-windows` resolves a Podman Windows installer download URL without installing it. Use it when your workflow needs the URL—for example, to download and install Podman on a remote Windows host.
+The composite sub-action at `.github/actions/fetch-latest-podman-version-windows` resolves a Podman Windows installer download URL without installing it. Use it when your workflow needs the URL -- for example, to download and install Podman on a remote Windows host.
 
 The main `podman-install` action uses this sub-action internally on Windows runners. It currently passes through `latest` or a specific release version only. To consume nightly CI builds, call the sub-action directly (see examples below).
 
@@ -92,7 +90,7 @@ The main `podman-install` action uses this sub-action internally on Windows runn
 | --- | --- | --- |
 | `latest` | [podman-container-tools/podman](https://github.com/podman-container-tools/podman) GitHub Release | `download_url` (public MSI/asset URL) |
 | `v5.6.1` / `5.6.1` | Same, pinned tag | `download_url` (public MSI/asset URL) |
-| `https://…` | URL used as-is (validated for CR/LF) | `download_url` |
+| `https://...` | URL used as-is (validated for CR/LF) | `download_url` |
 | `nightly` / `main` | Latest successful [release-pipeline-validation.yml](https://github.com/podman-container-tools/podman/actions/workflows/release-pipeline-validation.yml) run; artifact `win-msi-<arch>-main-<sha>` | `download_url` (Actions artifact archive URL) |
 
 `file_type` applies to release downloads only. Nightly resolution always targets the MSI CI artifact (`win-msi-<arch>-main-<sha>`).
@@ -112,7 +110,7 @@ Release assets are public download URLs. Nightly `download_url` is the GitHub Ac
 | `version_input` | yes | `latest` | Version selector (see table above) |
 | `architecture` | no | `amd64` | Windows architecture: `amd64` or `arm64` |
 | `file_type` | no | `msi` | Release asset type: `msi`, `setup.exe`, `installer.exe`, or `remote.zip` |
-| `github_token` | no* | — | GitHub token; *required for nightly |
+| `github_token` | no* | -- | GitHub token; *required for nightly |
 
 ### Outputs
 
@@ -131,7 +129,7 @@ permissions:
 
 steps:
   - id: fetch-podman
-    uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@main
+    uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@v1
     with:
       version_input: latest
       file_type: msi
@@ -144,7 +142,7 @@ steps:
 
 ```yaml
   - id: fetch-podman
-    uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@main
+    uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@v1
     with:
       version_input: v5.6.1
       architecture: amd64
@@ -160,7 +158,7 @@ permissions:
 
 steps:
   - id: fetch-podman
-    uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@main
+    uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@v1
     with:
       version_input: nightly
       architecture: amd64
@@ -174,4 +172,4 @@ steps:
       unzip -qo podman-nightly.zip
 ```
 
-Pin the sub-action to a commit SHA instead of `@main` in production workflows.
+Pin the sub-action to a commit SHA instead of `@v1` in production workflows.


### PR DESCRIPTION
## Summary

- Update all usage examples to reference `@v1` instead of `@main`
- Add proper inputs table documenting all 7 inputs (previously `install-scope` and `allow-upgrade` were undocumented)
- Clean up prose and formatting

This is a docs-only change in preparation for the v1.0.0 release.

## Test plan

- [ ] CI passes (no functional changes)
- [ ] Review rendered README on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)