### PR TITLE
fix: auto-detect Ubuntu version for podman installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ permissions:
   contents: read
 
 jobs:
-  test-linux:
-    name: Test on Linux (ubuntu-24.04)
+  test-linux-auto:
+    name: Test on Linux (ubuntu-24.04, auto)
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -47,8 +47,24 @@ jobs:
 
       - name: Install Podman
         uses: ./
-        with:
-          ubuntu-repository: questing
+
+      - name: Verify Podman is installed
+        run: |
+          set -euo pipefail
+          echo "Podman version:"
+          podman --version
+          echo "Podman info:"
+          podman info --format '{{.Host.OS}} {{.Host.Arch}} {{.Version.Version}}'
+
+  test-linux-2604:
+    name: Test on Linux (ubuntu-26.04, auto)
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Podman
+        uses: ./
 
       - name: Verify Podman is installed
         run: |
@@ -59,7 +75,7 @@ jobs:
           podman info --format '{{.Host.OS}} {{.Host.Arch}} {{.Version.Version}}'
 
   test-linux-arm:
-    name: Test on Linux ARM (ubuntu-24.04-arm)
+    name: Test on Linux ARM (ubuntu-24.04-arm, auto)
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
@@ -67,8 +83,6 @@ jobs:
 
       - name: Install Podman
         uses: ./
-        with:
-          ubuntu-repository: questing
 
       - name: Verify Podman is installed
         run: |

--- a/action.yml
+++ b/action.yml
@@ -20,18 +20,6 @@ name: "Install Podman"
 description: "Installs Podman on Linux, or a specific/latest version on Windows."
 
 inputs:
-  ubuntu-version:
-    description: "The Ubuntu version codename for the Kubic repository."
-    required: false
-    default: "23.10"
-  ubuntu-repository:
-    description: "The Ubuntu distro source to use for podman, ie: questing, resolute, noble. Or use openSUSE's kubic repo"
-    required: false
-    default: questing
-  allow-upgrade:
-    description: "Allow upgrade of the Ubuntu system, defaults to false"
-    required: false
-    default: 'false'
   podman-version-input:
     description: "Podman version for Windows. Use 'latest' or a specific version (e.g. '5.6.2')."
     required: false
@@ -51,73 +39,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Update podman to 5.x on Linux from Kubic repository
-      if: ${{ runner.os == 'Linux' && inputs.ubuntu-repository == 'kubic' }}
-      shell: bash
-      run: |
-        set -euo pipefail
-        ubuntu_version='${{ inputs.ubuntu-version }}'
-        echo "INFO: Using Ubuntu version '${ubuntu_version}' for Kubic repository."
-
-        echo "INFO: Adding Kubic repository..."
-        sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
-        curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/kubic.gpg
-
-        echo "INFO: Updating package list..."
-        sudo apt-get update -qq
-
-        echo "INFO: Installing CRIU dependencies..."
-        sudo apt-get install --allow-unauthenticated -qq -y libprotobuf32t64 python3-protobuf libnet1
-
-        echo "INFO: Installing CRIU manually..."
-        ARCH=$(dpkg --print-architecture)
-        curl -sLO "http://archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_${ARCH}.deb" && sudo dpkg -i "criu_3.16.1-2_${ARCH}.deb"
-
-        echo "INFO: Installing Podman..."
-        sudo apt-get -qq -y install --allow-unauthenticated podman || {
-          echo "WARN: Primary installation failed. Trying fallback repository..."
-          sudo sh -c "echo 'deb http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
-          curl -fsSL "http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/kubic-fallback.gpg
-          sudo apt-get --allow-insecure-repositories update -qq
-          sudo apt-get --allow-unauthenticated -y install podman
-        }
-
-        echo "INFO: Podman installation complete."
-        podman version
-
-    - name: Update podman to 5.x on Linux from ${{ inputs.ubuntu-repository }} repository
-      if: ${{ runner.os == 'Linux' && inputs.ubuntu-repository != 'kubic' }}
+    - name: Install podman on Linux
+      if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: |
         set -eux
-        ubuntu_repo="${{ inputs.ubuntu-repository }}"
-        allow_upgrade="${{ inputs.allow-upgrade }}"
-        echo "INFO: Using ${ubuntu_repo} Ubuntu repository for podman installation."
-        echo "INFO: The system upgrade is allowed: ${allow_upgrade}"
-        # Require the runner is ubuntu-24.04
         IDV=$(. /usr/lib/os-release && echo ${ID}-${VERSION_ID})
         echo "Actual Ubuntu version: ${IDV}"
-        echo "deb http://azure.archive.ubuntu.com/ubuntu ${ubuntu_repo} universe main" | sudo tee /etc/apt/sources.list.d/${ubuntu_repo}.list
-        /bin/time -f '%E %C' sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/${ubuntu_repo}.list" \
-          -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-        # Disable auto upgrade for this repository by default
-        if [ "${allow_upgrade}" == "false" ]; then
-          sudo tee /etc/apt/preferences.d/${ubuntu_repo} <<EOF
-        Package: *
-        Pin: release n=${ubuntu_repo}
-        Pin-Priority: 50
-        
-        Package: podman criu crun skopeo buildah
-        Pin: release n=${ubuntu_repo}
-        Pin-Priority: 500
-        EOF
-        fi
-        /bin/time -f '%E %C' sudo apt install -y --allow-downgrades criu/${ubuntu_repo} crun/${ubuntu_repo} podman/${ubuntu_repo} skopeo/${ubuntu_repo}
-        AFTER_IDV=$(. /usr/lib/os-release && echo ${ID}-${VERSION_ID})
-        if [[ "$AFTER_IDV" != "$IDV" ]]; then
-          echo "### WARNING Ubuntu was upgraded from $IDV to $AFTER_IDV"
-        fi
-        echo "Actual ubuntu version: ${AFTER_IDV}"
+
+        /bin/time -f '%E %C' sudo apt-get update
+        /bin/time -f '%E %C' sudo apt install -y podman crun skopeo
         echo "Actual podman installed: $(podman -v)"
 
     - name: Start Podman socket service


### PR DESCRIPTION
## Summary
- Install podman from the runner's native repositories instead of cross-installing from a different Ubuntu release
- Remove the retired openSUSE Kubic installation path
- Remove `ubuntu-version`, `ubuntu-repository`, and `allow-upgrade` inputs — users control which packages they get by choosing their runner (e.g. `runs-on: ubuntu-26.04`)
- Add `ubuntu-26.04` CI coverage

Closes #31

## Test plan
- [ ] `ubuntu-24.04` with no inputs — native install
- [ ] `ubuntu-26.04` with no inputs — native install (the scenario from #31)
- [ ] `ubuntu-24.04-arm` with no inputs — ARM native install
- [ ] Windows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)